### PR TITLE
Binary Search Tree.

### DIFF
--- a/MantleData/ObjectCollection.swift
+++ b/MantleData/ObjectCollection.swift
@@ -173,8 +173,6 @@ public final class ObjectCollection<E: NSManagedObject> {
 			return
 		}
 
-		hasFetched = true
-
 		func completion(_ results: [NSDictionary]) {
 			// Search inserted objects in the context.
 			let inMemoryResults = context.insertedObjects
@@ -186,6 +184,8 @@ public final class ObjectCollection<E: NSManagedObject> {
 			sectionize(using: results, inMemoryResults: inMemoryResults)
 			prefetcher?.acknowledgeFetchCompletion(results.count)
 			eventObserver.send(value: .reloaded)
+
+			hasFetched = true
 		}
 
 		do {


### PR DESCRIPTION
1. Fast O(log N) insertion & deletion for increasingly large N.
   `master` uses binary search on array O(N) on average. Significantly faster than `NSFetchedResultsController`.
2. Amortized O(1) reads.
   An O(n) cache update after every merge. On par with `master`, slightly faster than `NSFetchedResultsController`.
